### PR TITLE
In testing I found mongo needed the 10-gen version to work. Edda has …

### DIFF
--- a/playbooks/roles/edda/vars/main.yml
+++ b/playbooks/roles/edda/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 ami_build: ami is defined and ami 
 not_ami_build: ami is not defined or not ami
-latest_successful_build_url: https://netflixoss.ci.cloudbees.com/job/edda-master/lastSuccessfulBuild/artifact/build/libs/edda-2.1-SNAPSHOT.war
+latest_successful_build_url: https://netflixoss.ci.cloudbees.com/job/edda-master/lastSuccessfulBuild/artifact/build/libs/edda-2.2.0-SNAPSHOT.war

--- a/playbooks/roles/mongodb/files/mongodb.repo
+++ b/playbooks/roles/mongodb/files/mongodb.repo
@@ -1,0 +1,5 @@
+[mongodb]
+name=MongoDB Repository
+baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/
+gpgcheck=0
+enabled=1

--- a/playbooks/roles/mongodb/tasks/main.yml
+++ b/playbooks/roles/mongodb/tasks/main.yml
@@ -7,11 +7,24 @@
   when: ansible_distribution == 'Ubuntu'
   tags: mongodb
   
+#- name: Install MongoDB (yum version)
+#  yum: pkg={{ item }} state=latest enablerepo=epel
+#  with_items:
+#    - mongodb
+#    - mongodb-server
+#  when: ansible_distribution == 'Amazon'
+#  tags: mongodb
+
+- name: Install Selected Yum Repository for MongoDB
+  copy: src=../files/mongodb.repo dest=/etc/yum.repos.d/mongodb.repo
+  when: ansible_distribution == 'Amazon'
+  tags: mongodb
+
 - name: Install MongoDB (yum version)
-  yum: pkg={{ item }} state=latest enablerepo=epel
+  yum: pkg={{ item }} state=latest
   with_items:
-    - mongodb
-    - mongodb-server
+    - mongo-10gen
+    - mongo-10gen-server
   when: ansible_distribution == 'Amazon'
   tags: mongodb
   


### PR DESCRIPTION
So, basically changed the .war file for edda to the current version and replaced (for yum in the Amazon Linux version) mongodb with a version from the 10-gen repository which requires a repo file as well.
