### PR TITLE
Fixing missing Config.groovy with Asgard

### DIFF
--- a/playbooks/roles/asgard/defaults/main.yml
+++ b/playbooks/roles/asgard/defaults/main.yml
@@ -7,3 +7,15 @@
 
   # BASIC auth password to access Asgard
   asgard_password: password
+
+  # Friendly AWS Account Name (will appear in header of Asgard page) Such as dev/build/stage/prod
+  aws_account_name: build
+
+  # AWS Account Number where asgard lives
+  aws_account_number: 11111
+
+  # AWS API Access ID
+  aws_access_id: ACCESS_ID_HERE
+
+  # AWS API Secret Key
+  aws_secret_key: SECRET_KEY_HERE

--- a/playbooks/roles/asgard/tasks/main.yml
+++ b/playbooks/roles/asgard/tasks/main.yml
@@ -11,6 +11,9 @@
 - name: Create Asgard Home at /usr/share/tomcat7/.asgard
   file: path=/usr/share/tomcat7/.asgard state=directory owner={{ tomcat_user }}  group={{ tomcat_user }}  mode=0755
 
+- name: Copy over Config.groovy file
+  template: src=Config.groovy.j2 dest=/usr/share/tomcat7/.asgard/Config.groovy owner={{ tomcat_user }}  group={{ tomcat_user }}  mode=0755
+
 - name: Copy local Asgard WAR file {{ local_war }}
   copy: src={{ local_war }} dest=/usr/local/tomcat/webapps/asgard.war
   when: local_war != ""
@@ -56,4 +59,4 @@
   when: asgard_enable_basic_auth == "yes"
   notify: restart tomcat
   tags: auth
- 
+

--- a/playbooks/roles/asgard/templates/Config.groovy.j2
+++ b/playbooks/roles/asgard/templates/Config.groovy.j2
@@ -1,0 +1,12 @@
+grails {
+    awsAccounts=['{{ aws_account_number }}']
+    awsAccountNames=['{{ aws_account_number }}':'{{ aws_account_name }}']
+}
+secret {
+    accessId='{{ aws_access_id }}'
+    secretKey='{{ aws_secret_key }}'
+}
+cloud {
+    accountName='{{ aws_account_name }}'
+    publicResourceAccounts=['amazon']
+}


### PR DESCRIPTION
There is an open issue with Asgard right now that causes a nasty on boot error about missing AWS credentials.
`com.amazonaws.AmazonClientException: Unable to load AWS credentials from any provider in the chain`

In speaking with some folks, it sounds like Netflix won't be adding many features to Asgard in the near future as they are working on other things. Thus, the only solution is to add a Config.groovy with all the values you need to boot (no more interactive prompt until this is fixed)

Official discussion: https://github.com/Netflix/asgard/issues/612
